### PR TITLE
feat(theme) : add Crimson theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,11 +42,11 @@
   --shadow: 0 8px 32px rgba(0, 8, 24, 0.6);
 }
 
-[data-theme="midnight-red"] {
+[data-theme="crimson"] {
   --bg: #040404;
   --bg-elev: #0b0909;
   --bg-card: rgba(255, 255, 255, 0.03);
-  --bg-card-hover: rgba(185, 28, 28, 0.08);
+  --bg-card-hover: rgba(117, 20, 20, 0.167);
   --border: rgba(185, 28, 28, 0.20);
   --border-strong: rgba(185, 28, 28, 0.45);
   --fg: #f5f5f5;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -42,6 +42,25 @@
   --shadow: 0 8px 32px rgba(0, 8, 24, 0.6);
 }
 
+[data-theme="midnight-red"] {
+  --bg: #040404;
+  --bg-elev: #0b0909;
+  --bg-card: rgba(255, 255, 255, 0.03);
+  --bg-card-hover: rgba(185, 28, 28, 0.08);
+  --border: rgba(185, 28, 28, 0.20);
+  --border-strong: rgba(185, 28, 28, 0.45);
+  --fg: #f5f5f5;
+  --fg-muted: #b4b4b4;
+  --accent: #b91c1c;
+  --accent-glow: rgba(185, 28, 28, 0.30);
+  --accent-fg: #ffffff;
+  --danger: #ef4444;
+  --success: #22c55e;
+  --warn: #f59e0b;
+  --radius: 14px;
+  --shadow: 0 8px 32px rgba(70, 0, 0, 0.35);
+}
+
 [data-theme="synthwave"] {
   --bg: #1a0a23;
   --bg-elev: #2a0f3a;

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -6,6 +6,7 @@ import type { ComponentProps } from "react";
 export const THEMES = [
   { id: "purple-dark", label: "Purple Dark", swatch: "#8b5cf6" },
   { id: "midnight", label: "Midnight", swatch: "#38bdf8" },
+  { id: "midnight-red", label: "Midnight Red", swatch: "#b91c1c" },
   { id: "synthwave", label: "Synthwave", swatch: "#ff38b8" },
   { id: "paper", label: "Paper", swatch: "#7c3aed" },
   { id: "terminal", label: "Terminal", swatch: "#00ff66" },

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -6,7 +6,7 @@ import type { ComponentProps } from "react";
 export const THEMES = [
   { id: "purple-dark", label: "Purple Dark", swatch: "#8b5cf6" },
   { id: "midnight", label: "Midnight", swatch: "#38bdf8" },
-  { id: "midnight-red", label: "Midnight Red", swatch: "#b91c1c" },
+  { id: "crimson", label: "Crimson", swatch: "#b91c1c" },
   { id: "synthwave", label: "Synthwave", swatch: "#ff38b8" },
   { id: "paper", label: "Paper", swatch: "#7c3aed" },
   { id: "terminal", label: "Terminal", swatch: "#00ff66" },


### PR DESCRIPTION
## Summary

This PR adds a new **Crimson** theme to the application.
The theme provides a clean, near-black background appearance with subtle crimson accents while staying consistent with the existing design language and theme architecture.

## Changes

- Added `crimson` to the available theme options
- Added a new `crimson` theme in `globals.css`
- Reused the existing CSS variable system without introducing new variables
- Integrated the theme with the existing theme switcher

## Design Goals

- Near-black background
- Subtle crimson accents and borders
- High contrast for improved readability
- Minimal red glow to maintain a clean, modern appearance

## Testing

- [x] Theme appears in the theme selector
- [x] Theme switches correctly
- [x] Existing themes continue to work as expected
- [x] Verified readability across the homepage and UI components

## Screenshots - Crimson theme 

<img width="1919" height="1027" alt="Screenshot 2026-08-02 165607" src="https://github.com/user-attachments/assets/5f97830a-a530-4dc3-9c49-01e7ca8e6463" />
